### PR TITLE
add --file and --no-status parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,27 @@ export SBUS_QA_PRIVATE_KEY=daf163359fb9***8863642af8029f5fa007ce5
 
 ### Usage
 
+Without --env parameter, default environment is local. (--env=local)
 ```shell script
 sbus orders.create-order '{"price":"3.141592"}'
 ```
 
+--env: Send request to a specific environment.
 ```shell script
 sbus orders.create-order '{"price":"3.141592"}' --env=qa
 ```
 
+--file: Indicates that request body (2. parameter), is a file and payload should be read from this file.
+```shell script
+sbus orders.create-order '/home/my-payloads/createorder.json' --file --env=qa
+```
+
+--no-status: Status code (like 200, 400) is omitted in response. Useful if you are parsing response with jq.
+```shell script
+sbus orders.create-order '{"price":"3.141592"}' --no-status --env=qa
+```
+
+--event: Send an event
 ```shell script
 sbus orders.order-updated '{"orderId":"123"}' --env=qa --event 
 ```
@@ -41,4 +54,5 @@ sbus register users/joe.smith --save-to-consul="consul.qa.example.co" --group=de
 
 ```shell
 sbus --help
+sbus send --help
 ```

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ var (
 	send              = app.Command("send", "Send a message to the service bus.").Default()
 	routingKey        = send.Arg("routing-key", "Routing key").Required().String()
 	requestBody       = send.Arg("request-body", "Request JSON body/JSON file").Required().String()
-	readyBodyFromFile = send.Flag("file", "Request request-body is a file").Default("false").Bool()
+	readyBodyFromFile = send.Flag("file", "request-body parameter is a file").Default("false").Bool()
 	noStatusCode      = send.Flag("no-status", "Exclude status code from response.").Default("false").Bool()
 	isEvent           = send.Flag("event", "Is it event?").Default("false").Bool()
 )


### PR DESCRIPTION
--file: indicates that second parameter is a file rather than a raw json payload. In this case file content is sent as payload.
--no-status: by default cli prints status code, which jq give error while parsing. This flag omit status code, so output can be parsed with jq.